### PR TITLE
Revert "New protagonist needs C++11"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: required
-dist: trusty
+sudo: false
 language: "ruby"
 before_install:
   - "npm install -g dredd"


### PR DESCRIPTION
Reverts apiaryio/dredd-hooks-ruby#11

As of dredd@1.4.0 this is now not needed anymore. We migrated towards a solution where equivalent [pure JS compiler](https://github.com/apiaryio/drafter.js) will be selected if compilation of C++11 isn't an option. While the performance of the JS compiler could be worse, the installation time should be significantly shorter.
