### PR TITLE
Refactor modularize DreddHooks::Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Ruby Hooks Handler for Dredd API Testing Framework
 
 Test your API with the [Dredd HTTP API testing framework](https://github.com/apiaryio/dredd) and write [hooks](http://dredd.readthedocs.org/en/latest/hooks/) in Ruby!
 
+> **DISCLAIMER**: This is an early version of _dred-hooks-ruby_, please be aware that it will not be stable until **v1.0.0**. At any moment, [feedback][issues] is welcome! : )
+
+  [issues]: https://github.com/apiaryio/dredd-hooks-ruby/issues
+
 Installation
 ------------
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,7 +4,7 @@ How to Add New Hooks
 Dredd does support new hooks? It's time to extend the Ruby DSL!
 
 Most of the new hooks definition is automated, but not everything yet.
-In order to enable your new hook in the DSL (`DreddHook::Methods`) and the `DreddHooks::Runner`:
+In order to enable your new hook:
 
 1. Determine if the hook is specific to a transaction or applies to all of them
 1. Add the _registration_ and _run_ method to the [runner spec][runner-spec]

--- a/lib/dredd_hooks/server.rb
+++ b/lib/dredd_hooks/server.rb
@@ -21,20 +21,6 @@ module DreddHooks
       @events_handler = EventsHandler.new
     end
 
-    def process_message message, client
-      event = message['event']
-      transaction = message['data']
-
-      transaction = events_handler.handle(event, transaction)
-
-      to_send = {
-        "uuid" => message['uuid'],
-        "event" => event,
-        "data" => transaction
-      }.to_json
-      client.puts to_send + "\n"
-    end
-
     def run
       loop do
         #Thread.abort_on_exception=true
@@ -54,5 +40,23 @@ module DreddHooks
         client.close
       end
     end
+
+    private
+
+      def process_message(message, client)
+        event = message['event']
+        transaction = message['data']
+
+        transaction = events_handler.handle(event, transaction)
+
+        to_send = {
+          "uuid" => message['uuid'],
+          "event" => event,
+          "data" => transaction
+        }.to_json
+        client.puts to_send + "\n"
+      end
+
   end
 end
+

--- a/lib/dredd_hooks/server.rb
+++ b/lib/dredd_hooks/server.rb
@@ -33,7 +33,7 @@ module DreddHooks
 
             messages.each do |message|
               response = process_message(message)
-              client.puts response + "\n"
+              client.puts response + MESSAGE_DELIMITER
             end
           end
         end

--- a/lib/dredd_hooks/server.rb
+++ b/lib/dredd_hooks/server.rb
@@ -72,7 +72,7 @@ module DreddHooks
                 messages.push JSON.parse(message)
               rescue JSON::ParserError
                 # If the message after the delimiter is not parseable JSON,
-                # then it's a chunk of next message, and should be put back
+                # then it's a chunk of the next message, and should be put back
                 # into the buffer.
                 buffer += message
                 messages

--- a/lib/dredd_hooks/server.rb
+++ b/lib/dredd_hooks/server.rb
@@ -23,7 +23,6 @@ module DreddHooks
 
     def run
       loop do
-        #Thread.abort_on_exception=true
         client = @server.accept
         STDERR.puts 'Dredd connected to Ruby Dredd hooks worker'
         @buffer.flush!
@@ -33,7 +32,8 @@ module DreddHooks
             messages = @buffer.unshift_messages
 
             messages.each do |message|
-              process_message(message, client)
+              response = process_message(message)
+              client.puts response + "\n"
             end
           end
         end
@@ -43,18 +43,17 @@ module DreddHooks
 
     private
 
-      def process_message(message, client)
+      def process_message(message)
         event = message['event']
         transaction = message['data']
 
         transaction = events_handler.handle(event, transaction)
 
-        to_send = {
+        response = {
           "uuid" => message['uuid'],
           "event" => event,
           "data" => transaction
         }.to_json
-        client.puts to_send + "\n"
       end
 
   end

--- a/lib/dredd_hooks/server/buffer.rb
+++ b/lib/dredd_hooks/server/buffer.rb
@@ -1,0 +1,46 @@
+require 'json'
+
+module DreddHooks
+  class Server
+
+    # Store JSON messages or part of them
+    class Buffer
+
+      def initialize(message_delimiter)
+        flush!
+        @message_delimiter = message_delimiter
+      end
+
+      def flush!
+        content = @content
+        @content = ""
+        content
+      end
+
+      def <<(string)
+        @content += string
+      end
+
+      def any_message?
+        @content.include? @message_delimiter
+      end
+
+      def unshift_messages
+        flush!.
+        split(@message_delimiter).
+        inject([]) { |messages, message|
+          begin
+            messages.push JSON.parse(message)
+          rescue JSON::ParserError
+            # If the message after the delimiter is not parseable JSON,
+            # then it's a chunk of the next message, and should be put back
+            # into the buffer.
+            @content += message
+            messages
+          end
+        }
+      end
+
+    end
+  end
+end

--- a/lib/dredd_hooks/server/events_handler.rb
+++ b/lib/dredd_hooks/server/events_handler.rb
@@ -1,0 +1,44 @@
+require 'dredd_hooks/runner'
+
+module DreddHooks
+  class Server
+    class EventsHandler
+
+      attr_reader :runner
+      private :runner
+
+      def initialize
+        @runner = Runner.instance
+      end
+
+      def handle(event, transaction)
+
+        if event == "beforeEach"
+          transaction = runner.run_before_each_hooks_for_transaction(transaction)
+          transaction = runner.run_before_hooks_for_transaction(transaction)
+        end
+
+        if event == "beforeEachValidation"
+          transaction = runner.run_before_each_validation_hooks_for_transaction(transaction)
+          transaction = runner.run_before_validation_hooks_for_transaction(transaction)
+        end
+
+        if event == "afterEach"
+          transaction = runner.run_after_hooks_for_transaction(transaction)
+          transaction = runner.run_after_each_hooks_for_transaction(transaction)
+        end
+
+        if event == "beforeAll"
+          transaction = runner.run_before_all_hooks_for_transaction(transaction)
+        end
+
+        if event == "afterAll"
+          transaction = runner.run_after_all_hooks_for_transaction(transaction)
+        end
+
+        transaction
+      end
+    end
+  end
+end
+

--- a/spec/lib/dredd_hooks/methods_spec.rb
+++ b/spec/lib/dredd_hooks/methods_spec.rb
@@ -12,36 +12,39 @@ module DreddHooks
 
     let(:hooks_file) { DummyHooksFile.new }
 
-    it 'defines #before', public: true do
-      expect(hooks_file).to respond_to :before
-    end
+    describe 'exposes the Ruby hooks DSL', public: true do
 
-    it 'defines #before_validation', public: true do
-      expect(hooks_file).to respond_to :before_validation
-    end
+      it 'defines #before' do
+        expect(hooks_file).to respond_to :before
+      end
 
-    it 'defines #after', public: true do
-      expect(hooks_file).to respond_to :after
-    end
+      it 'defines #before_validation' do
+        expect(hooks_file).to respond_to :before_validation
+      end
 
-    it 'defines #before_each', public: true do
-      expect(hooks_file).to respond_to :before_each
-    end
+      it 'defines #after' do
+        expect(hooks_file).to respond_to :after
+      end
 
-    it 'defines #before_each_validation', public: true do
-      expect(hooks_file).to respond_to :before_each_validation
-    end
+      it 'defines #before_each' do
+        expect(hooks_file).to respond_to :before_each
+      end
 
-    it 'defines #after_each', public: true do
-      expect(hooks_file).to respond_to :after_each
-    end
+      it 'defines #before_each_validation' do
+        expect(hooks_file).to respond_to :before_each_validation
+      end
 
-    it 'defines #before_all', public: true do
-      expect(hooks_file).to respond_to :before_all
-    end
+      it 'defines #after_each' do
+        expect(hooks_file).to respond_to :after_each
+      end
 
-    it 'defines #after_all', public: true do
-      expect(hooks_file).to respond_to :after_all
+      it 'defines #before_all' do
+        expect(hooks_file).to respond_to :before_all
+      end
+
+      it 'defines #after_all' do
+        expect(hooks_file).to respond_to :after_all
+      end
     end
 
     it 'does not expose its #runner', private: true do

--- a/spec/lib/dredd_hooks/methods_spec.rb
+++ b/spec/lib/dredd_hooks/methods_spec.rb
@@ -50,6 +50,13 @@ module DreddHooks
     it 'does not expose its #runner', private: true do
       expect(hooks_file).not_to respond_to :runner
     end
+
+    describe 'does not expose its generator methods', private: true do
+
+      it { expect(DreddHooks::Methods).not_to respond_to :define_hooks_on_multiple_transactions }
+      it { expect(DreddHooks::Methods).not_to respond_to :define_hooks_on_single_transactions }
+
+    end
   end
 end
 

--- a/spec/lib/dredd_hooks/server/buffer_spec.rb
+++ b/spec/lib/dredd_hooks/server/buffer_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+module DreddHooks
+  describe Server::Buffer, private: true do
+
+    let(:message_delimiter) { "\t" }
+    let(:buffer) { described_class.new(message_delimiter) }
+
+    it { expect(buffer).to respond_to :<< }
+    it { expect(buffer).to respond_to :flush! }
+    it { expect(buffer).to respond_to :unshift_messages }
+    it { expect(buffer).to respond_to :any_message? }
+
+    it 'is empty by default' do
+      expect(buffer.any_message?).to be false
+    end
+
+    describe '#any_message?' do
+
+      it { expect(buffer.any_message?).to be false }
+
+      context "when the buffer contains part of a message" do
+
+        it {
+          buffer << '{ "note": "This string contains no message delimiter..." }'
+          expect(buffer.any_message?).to be false
+        }
+      end
+
+      context "when the buffer contains at least one message" do
+
+        it {
+          buffer << "{ \"note\": \"This string does contain a message delimiter...\" }\t{ \"and\": \"some\", \"more\": \"stuff which is not even valid JSON.... aAAAah! "
+          expect(buffer.any_message?).to be true
+        }
+      end
+    end
+
+    describe '#unshift_messages' do
+
+      before(:each) do
+        buffer << "{ \"A\": \"JSON message\" }\t"
+        buffer << "{ \"another\": \"message\" }\t{ \"and a\": \"half\","
+      end
+
+      it 'returns an array of messages' do
+        expect(buffer.unshift_messages).to eq [{ 'A' => 'JSON message' }, { 'another' => 'message' }]
+      end
+
+      it 'keeps the uncomplete messages intact' do
+        buffer.unshift_messages
+        expect(buffer.flush!).to eq '{ "and a": "half",'
+      end
+    end
+
+  end
+end
+

--- a/spec/lib/dredd_hooks/server/events_handler_spec.rb
+++ b/spec/lib/dredd_hooks/server/events_handler_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+module DreddHooks
+  describe Server::EventsHandler, private: true do
+
+   let(:events_handler) { described_class.new }
+
+   it { expect(events_handler).to respond_to :handle }
+
+   describe '#handle' do
+
+     it 'returns a transaction' do
+       event = 'do_nothing'
+       transaction = double()
+       expect(events_handler.handle(event, transaction)).to eq transaction
+     end
+   end
+  end
+end
+


### PR DESCRIPTION
**As a** developer
**In order to** keep simple the code which is likely to be extended
**And** keep apart the different responsibilities it assumes
**I want** the `DreddHooks::Server` to be modular

See https://github.com/apiaryio/dredd-hooks-ruby/issues/13
