### PR TITLE
Refactor ensure DreddHooks::Server can be used as library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.1.0] - [Unreleased]
+## 0.1.0 - [Unreleased]
 
 ### Added
 
 - This change log : )
+- Possibility to use DreddHooks::Server as a library (see DreddHooks::CLI for an example)
 
 ### Changed
 
@@ -27,8 +28,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 The original [proof of concept][poc] was written by @netmilk.
 
+
+[Unreleased]: https://github.com/gonzalo-bulnes/dredd-hooks-ruby/compare/v0.0.1...gonzalo-bulnes:gonzalo-bulnes/refactor-ensure-server-can-be-used-as-library?expand=1
 [poc]: https://github.com/gonzalo-bulnes/dredd-rack/issues/7#issue-70936733
-[0.1.0]: https://github.com/gonzalo-bulnes/dredd-hooks-ruby/compare/v0.0.1...v0.1.0
 
 ## Inspiration
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,6 @@ PLATFORMS
 
 DEPENDENCIES
   aruba (~> 0.6.2)
-  bundler (~> 1.6)
   dredd_hooks!
   rake (~> 10.0)
   rspec (~> 3.0)

--- a/bin/dredd-hooks-ruby
+++ b/bin/dredd-hooks-ruby
@@ -4,4 +4,3 @@ $LOAD_PATH.push File.join(File.dirname(__FILE__), "/../lib" )
 require 'dredd_hooks/cli'
 
 DreddHooks::CLI.start(ARGV)
-

--- a/dredd_hooks.gemspec
+++ b/dredd_hooks.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["{features,spec}/**/*"]
 
   spec.add_development_dependency "aruba", "~> 0.6.2"
-  spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "sinatra", "~> 1.4.5"

--- a/lib/dredd_hooks/cli.rb
+++ b/lib/dredd_hooks/cli.rb
@@ -5,10 +5,6 @@ module DreddHooks
 
     def self.start(error=STDERR, out=STDOUT)
 
-      # Disables stdout buffering. This makes node.js able to capture stdout of this process with no delay
-      # http://stackoverflow.com/questions/23001033/how-to-live-stream-output-from-ruby-script-using-child-process-spawn
-      out.sync = true
-
       # Load all files given on the command-line
       DreddHooks::FileLoader.load(ARGV)
 

--- a/lib/dredd_hooks/cli.rb
+++ b/lib/dredd_hooks/cli.rb
@@ -9,7 +9,6 @@ module DreddHooks
       DreddHooks::FileLoader.load(files)
 
       # Run the server
-
       out.puts 'Starting Ruby Dredd Hooks Worker...'
       server = DreddHooks::Server.new(error, out)
       server.run

--- a/lib/dredd_hooks/cli.rb
+++ b/lib/dredd_hooks/cli.rb
@@ -3,10 +3,10 @@ require 'dredd_hooks'
 module DreddHooks
   class CLI
 
-    def self.start(error=STDERR, out=STDOUT)
+    def self.start(error=STDERR, out=STDOUT, files)
 
       # Load all files given on the command-line
-      DreddHooks::FileLoader.load(ARGV)
+      DreddHooks::FileLoader.load(files)
 
       # Run the server
 

--- a/lib/dredd_hooks/server.rb
+++ b/lib/dredd_hooks/server.rb
@@ -24,6 +24,7 @@ module DreddHooks
     end
 
     def run
+      disable_buffering(out)
       loop do
         client = server.accept
         out.puts 'Dredd connected to Ruby Dredd hooks worker'
@@ -44,6 +45,14 @@ module DreddHooks
     end
 
     private
+
+      # Write to a file (e.g. STDOUT) without delay
+      #
+      # See https://stackoverflow.com/q/23001033
+      # and http://ruby-doc.org/core-2.3.1/IO.html#method-i-sync-3D
+      def disable_buffering(file)
+        file.sync = true
+      end
 
       def process_message(message)
         event = message['event']

--- a/lib/dredd_hooks/server/buffer.rb
+++ b/lib/dredd_hooks/server/buffer.rb
@@ -11,6 +11,9 @@ module DreddHooks
         @message_delimiter = message_delimiter
       end
 
+      # Empty the buffer.
+      #
+      # Returns the buffer content String.
       def flush!
         content = @content
         @content = ""


### PR DESCRIPTION
**As a** developer
**In order to** provide multiple uses to my gem
**I want** its code to be usable without its command-line interface

See https://github.com/apiaryio/dredd-hooks-ruby/issues/5

I'll add no specific documentation for this yet. However, and example of the `DreddHooks::Server` usage can be found in `DreddHooks::CLI`.
