### PR TITLE
Alert the user when no hook files are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Alert the user when no hook files are found
+
 ## [0.1.0] - 2016-08-06
 
 ### Added


### PR DESCRIPTION
Silly, but I just spent an hour trying to figure out why my hooks weren't firing and logging wasn't working. Turns out it was just because I'd screwed up the path to my hooks.  Ridiculous, but there was nothing to alert me that this was the cause. This just adds a log message when no files are matched. Maybe it'll save someone else a little sanity.