### PR TITLE
Update dependency: Aruba

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aruba (0.6.2)
-      childprocess (>= 0.3.6)
-      cucumber (>= 1.1.1)
-      rspec-expectations (>= 2.7.0)
+    aruba (0.14.2)
+      childprocess (~> 0.5.6)
+      contracts (~> 0.9)
+      cucumber (>= 1.3.19)
+      ffi (~> 1.9.10)
+      rspec-expectations (>= 2.99)
+      thor (~> 0.19)
     builder (3.2.2)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
+    contracts (0.14.0)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -50,13 +54,14 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    thor (0.19.4)
     tilt (2.0.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  aruba (~> 0.6.2)
+  aruba (~> 0.14.0)
   dredd_hooks!
   rake (~> 10.0)
   rspec (~> 3.0)

--- a/dredd_hooks.gemspec
+++ b/dredd_hooks.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["{bin,doc,lib}/**/*", "CHANGELOG.md", "Gemfile", "LICENSE.txt", "Rakefile", "README.md" ]
   spec.test_files    = Dir["{features,spec}/**/*"]
 
-  spec.add_development_dependency "aruba", "~> 0.6.2"
+  spec.add_development_dependency "aruba", "~> 0.14.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "sinatra", "~> 1.4.5"

--- a/features/execution_order.feature
+++ b/features/execution_order.feature
@@ -19,7 +19,6 @@ Feature: Execution order
           Hello World!
       """
 
-  @debug
   Scenario:
     Given a file named "hookfile.rb" with:
       """

--- a/features/failing_transaction.feature
+++ b/features/failing_transaction.feature
@@ -19,7 +19,6 @@ Feature: Failing a transaction
           Hello World!
       """
 
-  @debug
   Scenario:
     Given a file named "hookfile.rb" with:
       """

--- a/features/hook_handlers.feature
+++ b/features/hook_handlers.feature
@@ -19,7 +19,6 @@ Feature: Hook handlers
           Hello World!
       """
 
-  @debug
   Scenario:
     Given a file named "hookfile.rb" with:
       """

--- a/features/multiple_hookfiles.feature
+++ b/features/multiple_hookfiles.feature
@@ -19,7 +19,6 @@ Feature: Multiple hookfiles with a glob
           Hello World!
       """
 
-  @debug
   Scenario:
     Given a file named "hookfile1.rb" with:
       """


### PR DESCRIPTION
**When I** test a Dredd hooks project (in this case the Ruby hooks) 
**I want** to use a recent version of Aruba 
**So that** its features are familiar to the Cucumber community 
**And** it is easier for everyone to contribute 

This PR is a follow up on https://github.com/apiaryio/dredd-hooks-ruby/pull/25

Fixes #26 