### PR TITLE
Add --host and --port flags for use in Docker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.3] - 2019-03-19
+
+## Added
+
+- Allow `--host` and `--port` to be set via CLI.
+- Ex: `dredd-hooks-ruby hooks.rb --host 0.0.0.0 --port 12345`
+- See https://github.com/apiaryio/dredd/issues/748#issuecomment-473010416 for more context.
+
 ## [0.1.2] - 2016-12-30
 
 ## Fixed
@@ -40,7 +48,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 The original [proof of concept][poc] was written by @netmilk.
 
-
+[0.1.3]: https://github.com/apiaryio/dredd-hooks-ruby/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/apiaryio/dredd-hooks-ruby/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/apiaryio/dredd-hooks-ruby/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/apiaryio/dredd-hooks-ruby/compare/v0.0.1...v0.1.0

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add the gem to your `Gemfile`:
 ```ruby
 # Gemfile
 
-gem 'dredd_hooks', '0.1.2' # see semver.org
+gem 'dredd_hooks', '0.1.3' # see semver.org
 ```
 
 Usage

--- a/bin/dredd-hooks-ruby
+++ b/bin/dredd-hooks-ruby
@@ -1,6 +1,25 @@
 #!/usr/bin/env ruby
 $LOAD_PATH.push File.join(File.dirname(__FILE__), "/../lib" )
 
+require 'optparse'
 require 'dredd_hooks/cli'
 
-DreddHooks::CLI.start(ARGV)
+options = {
+  host: '127.0.0.1',
+  port: 61321
+}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: dredd-hooks-ruby [options] files"
+
+  opts.on('-h', '--host HOST', String, 'The host to listen on (default: 127.0.0.1)') do |h|
+    options[:host] = h
+  end
+
+  opts.on('-p', '--port PORT', Integer, 'The port to listen on (default: 61321)') do |p|
+    options[:port] = p
+  end
+end.parse!
+
+
+DreddHooks::CLI.start(host = options[:host], port = options[:port], ARGV)

--- a/lib/dredd_hooks/cli.rb
+++ b/lib/dredd_hooks/cli.rb
@@ -3,14 +3,14 @@ require 'dredd_hooks'
 module DreddHooks
   class CLI
 
-    def self.start(error=STDERR, out=STDOUT, files)
+    def self.start(host=DreddHooks::Server::HOST, port=DreddHooks::Server::PORT, error=STDERR, out=STDOUT, files)
 
       # Load all files given on the command-line
       DreddHooks::FileLoader.load(files)
 
       # Run the server
       out.puts 'Starting Ruby Dredd Hooks Worker...'
-      server = DreddHooks::Server.new(error, out)
+      server = DreddHooks::Server.new(host, port, error, out)
       server.run
     end
   end

--- a/lib/dredd_hooks/server.rb
+++ b/lib/dredd_hooks/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literals: true
+
 require 'socket'
 
 require 'dredd_hooks/server/buffer'
@@ -15,10 +17,10 @@ module DreddHooks
     PORT = 61321
     MESSAGE_DELIMITER = "\n"
 
-    def initialize(error=STDERR, out=STDOUT)
+    def initialize(host=HOST, port=PORT, error=STDERR, out=STDOUT)
       @error = error
       @out = out
-      @server = TCPServer.new(HOST, PORT)
+      @server = TCPServer.new(host, port)
       @buffer = Buffer.new(MESSAGE_DELIMITER)
       @events_handler = EventsHandler.new
     end


### PR DESCRIPTION
* When running in a separate docker container from the main
  Dredd process, the hooks server will need to listen on 0.0.0.0
  for instance, and optionally on a different port.