### PR TITLE
Allow custom host and ports via CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.3] - 2019-03-14
+
+## Added
+
+- Allow `--host` and `--port` to be set via CLI.
+- Ex: `dredd-hooks-ruby hooks.rb --host 0.0.0.0 --port 12345`
+- See https://github.com/apiaryio/dredd/issues/748#issuecomment-473010416 for more context.
+
 ## [0.1.2] - 2016-12-30
 
 ## Fixed
@@ -41,6 +49,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The original [proof of concept][poc] was written by @netmilk.
 
 
+[0.1.3]: https://github.com/apiaryio/dredd-hooks-ruby/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/apiaryio/dredd-hooks-ruby/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/apiaryio/dredd-hooks-ruby/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/apiaryio/dredd-hooks-ruby/compare/v0.0.1...v0.1.0

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add the gem to your `Gemfile`:
 ```ruby
 # Gemfile
 
-gem 'dredd_hooks', '0.1.2' # see semver.org
+gem 'dredd_hooks', '0.1.3' # see semver.org
 ```
 
 Usage

--- a/bin/dredd-hooks-ruby
+++ b/bin/dredd-hooks-ruby
@@ -2,5 +2,18 @@
 $LOAD_PATH.push File.join(File.dirname(__FILE__), "/../lib" )
 
 require 'dredd_hooks/cli'
+require 'optparse'
 
-DreddHooks::CLI.start(ARGV)
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: hooks.rb [options]"
+
+  opts.on("-h", "--host [HOST]", "Pass in host IP") do |host|
+    options[:host] = host
+  end
+  opts.on("-p", "--port [PORT]", Integer, "Pass in port number") do |port|
+    options[:port] = port
+  end
+end.parse!
+
+DreddHooks::CLI.start(options, ARGV)

--- a/lib/dredd_hooks/cli.rb
+++ b/lib/dredd_hooks/cli.rb
@@ -3,14 +3,14 @@ require 'dredd_hooks'
 module DreddHooks
   class CLI
 
-    def self.start(error=STDERR, out=STDOUT, files)
+    def self.start(error=STDERR, out=STDOUT, options, files)
 
       # Load all files given on the command-line
       DreddHooks::FileLoader.load(files)
 
       # Run the server
-      out.puts 'Starting Ruby Dredd Hooks Worker...'
-      server = DreddHooks::Server.new(error, out)
+      out.print 'Starting Ruby Dredd Hooks Worker...'
+      server = DreddHooks::Server.new(error, out, options)
       server.run
     end
   end

--- a/lib/dredd_hooks/server.rb
+++ b/lib/dredd_hooks/server.rb
@@ -15,10 +15,15 @@ module DreddHooks
     PORT = 61321
     MESSAGE_DELIMITER = "\n"
 
-    def initialize(error=STDERR, out=STDOUT)
+    def initialize(error=STDERR, out=STDOUT, options={})
       @error = error
       @out = out
-      @server = TCPServer.new(HOST, PORT)
+
+      ## Set host/port if they are passed in through CLI
+      host = options[:host] || HOST
+      port = options[:port] || PORT
+      out.puts "on host:port #{host}:#{port}..."
+      @server = TCPServer.new(host, port)
       @buffer = Buffer.new(MESSAGE_DELIMITER)
       @events_handler = EventsHandler.new
     end


### PR DESCRIPTION
This will allow you to change the port and host of the hooks server. This is most useful for Docker containers.

ex. `dredd-hooks-ruby ./hooks.rb -h 0.0.0.0 -p 12345`

See: https://github.com/apiaryio/dredd/issues/748#issuecomment-473010416