### PR TITLE
Drop support for older Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 sudo: false
 language: "ruby"
 rvm:
-  - "1.9.3"
-  - "2.2.4"
-  - "2.4"
-  # - "2.5" https://github.com/apiaryio/dredd-hooks-ruby/issues/36
+  - "2.5"
   - "2.6"
+  - "2.7"
 before_install:
   - "nvm install node && nvm use node"
   - "npm install"


### PR DESCRIPTION
BREAKING CHANGE: Rubies 1.9.3, 2.2.4, and 2.4 are no longer supported

Closes https://github.com/apiaryio/dredd-hooks-ruby/issues/36, enables https://github.com/apiaryio/dredd-hooks-ruby/pull/43